### PR TITLE
Node v4 doesn't allow fs.read of 0 bytes on a 0 byte buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,6 +94,8 @@ class ReadStream extends MiniPass {
     if (!this[_reading]) {
       this[_reading] = true
       const buf = this[_makeBuf]()
+      /* istanbul ignore if */
+      if (buf.length === 0) return process.nextTick(this[_onread], null, 0, buf)
       fs.read(this[_fd], buf, 0, buf.length, null, (er, br, buf) =>
         this[_onread](er, br, buf))
     }
@@ -172,7 +174,8 @@ class ReadStreamSync extends ReadStream {
         this[_reading] = true
         do {
           const buf = this[_makeBuf]()
-          const br = fs.readSync(this[_fd], buf, 0, buf.length, null)
+          /* istanbul ignore next */
+          const br = buf.length === 0 ? 0 : fs.readSync(this[_fd], buf, 0, buf.length, null)
           if (!this[_handleChunk](br, buf))
             break
         } while (true)


### PR DESCRIPTION
No test, as I can repro this in the npm test suite but I have figured out what it's doing that triggers this as yet. Obvious things like 0 byte files and exact block boundary reads don't trigger it.

The test failure is below:
```
# Subtest: test/tap/bundled-dependencies.js
    # Subtest: basic bundling
        ok 1 - pack went ok
        not ok 2 - Offset is out of bounds
          ---
          stack: >
            Error (native)
          
            ReadStream.fs.read (node_modules/tar/node_modules/fs-minipass/index.js:97:10)
          
            ReadStream.emit (node_modules/tar/node_modules/fs-minipass/index.js:147:22)
          
            ReadStream.EE.set.enc (node_modules/tar/node_modules/minipass/index.js:165:12)
          
            Unpack.p.ondrain._ (node_modules/tar/node_modules/minipass/index.js:212:67)
          
            Unpack.module.exports.EE.constructor.re.once
            (node_modules/tar/lib/parse.js:192:16)
          
            Unpack.module.exports.EE.constructor.entry.on
            (node_modules/tar/lib/parse.js:148:30)
          
            Unpack.module.exports.EE.constructor.entry.write.chunk.(anonymous
            function).on.(anonymous function).on.(anonymous function).on.chunk
            (node_modules/tar/lib/parse.js:381:30)
          
            Unpack.module.exports.EE.constructor.entry.write.chunk.(anonymous
            function).on.(anonymous function).on.(anonymous function).on.chunk
            (node_modules/tar/lib/parse.js:358:30)
          
            Unzip.<anonymous> (node_modules/tar/lib/parse.js:290:59)
          
            Unzip.emit (node_modules/tar/node_modules/minipass/index.js:287:25)
          at:
            native: true
            function: Error
          test: basic bundling
          ...
        
        1..2
        # failed 1 of 2 tests
    not ok 1 - basic bundling # time=986.031ms
    ```