### PR TITLE
Use `Buffer.from()` instead of `new Buffer`

### DIFF
--- a/index.js
+++ b/index.js
@@ -267,7 +267,7 @@ class WriteStream extends EE {
 
   write (buf, enc) {
     if (typeof buf === 'string')
-      buf = new Buffer(buf, enc)
+      buf = Buffer.from(buf, enc)
 
     if (this[_ended]) {
       this.emit('error', new Error('write() after end()'))


### PR DESCRIPTION
The `Buffer` constructor is deprecated, we should
use `Buffer.from()` instead.

Refs: https://github.com/nodejs/node/issues/19079