### PR TITLE
avoid process.binding() where possible

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ const fs = require('fs')
 let writev = fs.writev
 /* istanbul ignore next */
 if (!writev) {
+  // This entire block can be removed if support for earlier than Node.js
+  // 12.9.0 is not needed.
   const binding = process.binding('fs')
   const FSReqWrap = binding.FSReqWrap || binding.FSReqCallback
 

--- a/index.js
+++ b/index.js
@@ -368,7 +368,7 @@ class WriteStreamSync extends WriteStream {
 }
 
 let writev = fs.writev
-/* istanbul ignore if */
+/* istanbul ignore next */
 if (!writev) {
   const binding = process.binding('fs')
   const writeBuffers = binding.writeBuffers

--- a/index.js
+++ b/index.js
@@ -371,7 +371,6 @@ let writev = fs.writev
 /* istanbul ignore next */
 if (!writev) {
   const binding = process.binding('fs')
-  const writeBuffers = binding.writeBuffers
   const FSReqWrap = binding.FSReqWrap || binding.FSReqCallback
 
   writev = (fd, iovec, pos, cb) => {


### PR DESCRIPTION
process.binding() is deprecated. When running recent versions of Node.js
with --pending-deprecation, the current code results in a printed
warning about process.binding() usage. process.binding() is used to
create writev(), but Node.js now exposes fs.writev(). Use that instead
when it exists. Otherwise, fall back to the polyfill. This will avoid
runtime deprecation messages for end users.

If the minimum supported engine is ever Node.js 12.9.0 or above, the
polyfill code should be removable at that time.