### PR TITLE
chore: add prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "fs-minipass",
   "version": "2.1.0",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "tap",
     "preversion": "npm test",
@@ -24,16 +25,30 @@
     "minipass": "^3.0.0"
   },
   "devDependencies": {
+    "@types/node": "^18.11.9",
     "mutate-fs": "^2.0.1",
-    "tap": "^15.0.10"
+    "tap": "^15.0.10",
+    "typescript": "^4.8.4"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "tap": {
     "check-coverage": true
   },
   "engines": {
     "node": ">= 8"
+  },
+  "prettier": {
+    "semi": false,
+    "printWidth": 80,
+    "tabWidth": 2,
+    "useTabs": false,
+    "singleQuote": true,
+    "jsxSingleQuote": false,
+    "bracketSameLine": true,
+    "arrowParens": "avoid",
+    "endOfLine": "lf"
   }
 }


### PR DESCRIPTION
Adds a prettier config (copied from `minipass`) and `devDependency` on `prettier`. This was mainly done so I could stay consistent with the code style while writing the type declarations. I did not reformat `index.js` using `prettier`, although I certainly could.

## References
Related to #20.
