### PR TITLE
fix: only flush the queue after open if not already writing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -290,7 +290,9 @@ class WriteStream extends EE {
     } else {
       this[_fd] = fd
       this.emit('open', fd)
-      this[_flush]()
+      if (!this[_writing]) {
+        this[_flush]()
+      }
     }
   }
 


### PR DESCRIPTION
this impacted code that followed a pattern like the following:

```
const s = fsm.createWriteStream(p)
s.on('open', () => {
  s.write('hello ')
  s.write('human')
  s.end()
})
```

since emitting the `open` event is synchronous and calls all of its handlers synchronously, the first write starts immediately and the second write is queued, then the `_onopen` method calls `_flush()` which races the `_onwrite` call from the first write. by only calling `_flush` if we're not already writing, we avoid this situation where flush gets called twice and we prevent lost data. 

for npm/statusboard#631
closes #24 
